### PR TITLE
fix: Remove unused _startMemory variable (Issue #198)

### DIFF
--- a/backend-express/src/routes/__tests__/stress-testing.test.ts
+++ b/backend-express/src/routes/__tests__/stress-testing.test.ts
@@ -227,7 +227,6 @@ describe('Event Bus Stress Testing - Suite 1: High-Throughput', () => {
 describe('Event Bus Stress Testing - Suite 2: Memory Leak Detection', () => {
   it('2.1: event bus memory stays stable over sustained load', async () => {
     const measurements: Array<{ time: number; memory: number }> = [];
-    const _startMemory = getHeapUsedMB();
     const metricsCollector = new EventBusMetricsCollector();
 
     // Run for 300 simulated seconds (5-minute equivalent)


### PR DESCRIPTION
Resolves #198: Removes unused `_startMemory` variable that was causing TS6133 build error in stress-testing.test.ts

## Changes
- Removed line 230: `const _startMemory = getHeapUsedMB();` from `backend-express/src/routes/__tests__/stress-testing.test.ts`

## Verification
- ✅ Build passes: `pnpm build` completes with no TS6133 errors
- ✅ Tests pass: `pnpm test:express` - all 135 tests pass
- ✅ No codebase references to `_startMemory` variable

The variable was declared but never used, causing TypeScript strict mode (TS6133) error.