### PR TITLE
Fix: Remove setState from useEffect in CreateBuildModal (Fixes #212)

### DIFF
--- a/frontend/components/build-dashboard.tsx
+++ b/frontend/components/build-dashboard.tsx
@@ -151,6 +151,7 @@ function BuildsTable({ initialBuilds }: BuildsTableProps): ReactElement {
       )}
 
       <CreateBuildModal
+        key={`modal-${isCreateModalOpen}`}
         isOpen={isCreateModalOpen}
         onClose={() => setIsCreateModalOpen(false)}
         onSubmit={handleCreateBuild}

--- a/frontend/components/create-build-modal.tsx
+++ b/frontend/components/create-build-modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type ReactElement, SubmitEvent, useEffect } from "react";
+import { useState, type ReactElement, SubmitEvent } from "react";
 
 interface CreateBuildModalProps {
   isOpen: boolean;
@@ -17,13 +17,6 @@ export function CreateBuildModal({
 }: CreateBuildModalProps): ReactElement | null {
   const [buildName, setBuildName] = useState('');
   const [error, setError] = useState('');
-
-  useEffect(() => {
-    if (!isOpen) {
-      setBuildName('');
-      setError('');
-    }
-  }, [isOpen]);
 
   if (!isOpen) return null;
 


### PR DESCRIPTION
## Summary
Removes React anti-pattern where setState was called directly in useEffect, causing unnecessary re-renders when modal opens/closes.

## Changes
- Removed useEffect that was calling setState on modal open/close
- Added key prop to parent component to force React to remount component
- This is the idiomatic React pattern for resetting component state

## Files Changed
- `frontend/components/create-build-modal.tsx` (removed useEffect)
- `frontend/components/build-dashboard.tsx` (added key prop)

## Verification
✅ TypeScript: PASS
✅ ESLint: PASS
✅ Tests: PASSING
✅ Performance: Improved (eliminates cascading renders)

Fixes #212