### PR TITLE
fix: Update Postgres health check command to include database parameter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-root}']
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-root} -d ${POSTGRES_DB:-boltline}']
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Root Cause

The error FATAL: database "root" does not exist was caused by the PostgreSQL healthcheck in docker-compose.yml:

test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-root}']  # ❌ Missing database name

When pg_isready connects without specifying a database, PostgreSQL defaults to connecting to a database named after the username (root), which
doesn't exist. The actual database is named boltline.

The Fix

Updated the health check to explicitly specify the database:

test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-root} -d ${POSTGRES_DB:-boltline}']  # ✅ Includes database

Verification

- ✅ Container now shows (healthy) status
- ✅ Zero FATAL errors after restart
- ✅ Database boltline accessible and working

The repeated errors were harmless to functionality (database was working fine), but they cluttered logs and affected service health reporting. The
fix ensures clean startup and proper health checks going forward.

Fix: #268 