### PR TITLE
fix: Add Tailwind CSS directives to globals.css

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 /* Global Styles */
 
 * {


### PR DESCRIPTION
## Issue
Fixes #282 - Missing @tailwind directives prevented PostCSS from injecting Tailwind utility classes into the compiled CSS.

## Root Cause
During the CSS refactoring (revisions a9005c2 and 357e3a1), the old CSS files were removed and components were converted to use Tailwind. However, the critical step of adding `@tailwind` directives to `globals.css` was overlooked.

## Solution
Added the three required Tailwind directives to the top of `frontend/app/globals.css`:
- `@tailwind base;`
- `@tailwind components;`
- `@tailwind utilities;`

## Verification
- ✅ Build completed successfully (0 errors)
- ✅ CSS file size increased to 27.7 KB (indicating Tailwind utilities injected)
- ✅ All 867 tests passing
- ✅ No TypeScript errors

## Affected Components
- build-dashboard.tsx
- build-detail-modal.tsx
- toast-notification.tsx
- TableSkeleton.tsx
- Pagination.tsx
- StatusBadge.tsx
- EmptyState.tsx

## Testing
Run `pnpm build` to verify the CSS is properly generated with Tailwind utility classes.